### PR TITLE
Add cache-control header to prevent checkout pages from being cached.

### DIFF
--- a/src/Umbraco.Commerce.Checkout/Web/Controllers/Filters/NoStoreCacheControlAttribute.cs
+++ b/src/Umbraco.Commerce.Checkout/Web/Controllers/Filters/NoStoreCacheControlAttribute.cs
@@ -1,0 +1,15 @@
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace Umbraco.Commerce.Checkout.Web.Controllers.Filters
+{
+    /// <summary>
+    /// Add "cache-control: no-store" header to the response.
+    /// </summary>
+    internal sealed class NoStoreCacheControlAttribute : ActionFilterAttribute
+    {
+        public override void OnActionExecuted(ActionExecutedContext context)
+        {
+            context.HttpContext.Response.Headers.CacheControl = "no-store";
+        }
+    }
+}

--- a/src/Umbraco.Commerce.Checkout/Web/Controllers/UmbracoCommerceCheckoutBaseController.cs
+++ b/src/Umbraco.Commerce.Checkout/Web/Controllers/UmbracoCommerceCheckoutBaseController.cs
@@ -6,9 +6,11 @@ using Umbraco.Cms.Core.Web;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Web.Common.Controllers;
 using Umbraco.Extensions;
+using Umbraco.Commerce.Checkout.Web.Controllers.Filters;
 
 namespace Umbraco.Commerce.Checkout.Web.Controllers
 {
+    [NoStoreCacheControl]
     public abstract class UmbracoCommerceCheckoutBaseController : RenderController
     {
         public UmbracoCommerceCheckoutBaseController(ILogger<UmbracoCommerceCheckoutBaseController> logger, ICompositeViewEngine compositeViewEngine, IUmbracoContextAccessor umbracoContextAccessor)


### PR DESCRIPTION
Currently, the checkout pages can be cached by browsers and user can navigate back to them (e.g: using browser's back button) and have weird issues.
This PR add a cache-control header to the response to tell browser not to cache the checkout pages.