### PR TITLE
Portal integration updates

### DIFF
--- a/src/Umbraco.Commerce.Checkout/Extensions/CustomerExtensions.cs
+++ b/src/Umbraco.Commerce.Checkout/Extensions/CustomerExtensions.cs
@@ -1,0 +1,39 @@
+using System;
+using Umbraco.Commerce.Checkout.Models;
+using Umbraco.Commerce.Core.Models;
+
+namespace Umbraco.Commerce.Checkout.Extensions;
+
+public static class CustomerExtensions
+{
+    public static Customer GetCustomer(this OrderReadOnly order, OrderPropertyConfig orderPropertyConfig) =>
+        new Customer(
+            order.CustomerInfo.FirstName,
+            order.CustomerInfo.LastName,
+            order.CustomerInfo.Email,
+            order.Properties[orderPropertyConfig.Customer.Telephone.Alias]);
+
+    public static CustomerAddress GetBillingAddress(this OrderReadOnly order, OrderPropertyConfig orderPropertyConfig)
+    {
+        // This extension method should not be used in a context where order is null.
+        ArgumentNullException.ThrowIfNull(order);
+
+        return new CustomerAddress(
+            order.Properties[orderPropertyConfig.Billing.AddressLine1.Alias],
+            order.Properties[orderPropertyConfig.Billing.AddressLine2.Alias],
+            order.Properties[orderPropertyConfig.Billing.City.Alias],
+            order.Properties[orderPropertyConfig.Billing.ZipCode.Alias]);
+    }
+
+    public static CustomerAddress GetShippingAddress(this OrderReadOnly order, OrderPropertyConfig orderPropertyConfig)
+    {
+        // This extension method should not be used in a context where order is null.
+        ArgumentNullException.ThrowIfNull(order);
+
+        return new CustomerAddress(
+            order.Properties[orderPropertyConfig.Shipping.AddressLine1.Alias],
+            order.Properties[orderPropertyConfig.Shipping.AddressLine2.Alias],
+            order.Properties[orderPropertyConfig.Shipping.City.Alias],
+            order.Properties[orderPropertyConfig.Shipping.ZipCode.Alias]);
+    }
+}

--- a/src/Umbraco.Commerce.Checkout/Models/Customer.cs
+++ b/src/Umbraco.Commerce.Checkout/Models/Customer.cs
@@ -1,0 +1,5 @@
+namespace Umbraco.Commerce.Checkout.Models;
+
+public record Customer(string FirstName, string LastName, string Email, string Telephone);
+
+public record CustomerAddress(string AddressLine1, string AddressLine2, string City, string ZipCode);

--- a/src/Umbraco.Commerce.Checkout/Pipeline/Tasks/CreateUmbracoCommerceCheckoutDocumentTypesTask.cs
+++ b/src/Umbraco.Commerce.Checkout/Pipeline/Tasks/CreateUmbracoCommerceCheckoutDocumentTypesTask.cs
@@ -194,6 +194,20 @@ namespace Umbraco.Commerce.Checkout.Pipeline.Tasks
                     x.Name = "Hide from Navigation";
                     x.Description = "Hide the checkout page from the sites main navigation.";
                     x.SortOrder = 90;
+                }),
+                CreatePropertyType(await booleanDataType.Value, x =>
+                {
+                    x.Alias = "uccRequireLogin";
+                    x.Name = "Require Login";
+                    x.Description = "Customer is required to login before proceeding with the checkout.";
+                    x.SortOrder = 100;
+                }),
+                CreatePropertyType(await contentPickerDataType.Value, x =>
+                {
+                    x.Alias = "uccLoginPage";
+                    x.Name = "Login Page";
+                    x.Description = "The page on the site containing the customer portal login.";
+                    x.SortOrder = 110;
                 })
             ];
 

--- a/src/Umbraco.Commerce.Checkout/Views/UmbracoCommerceCheckout/UmbracoCommerceCheckoutInformationPage.cshtml
+++ b/src/Umbraco.Commerce.Checkout/Views/UmbracoCommerceCheckout/UmbracoCommerceCheckoutInformationPage.cshtml
@@ -1,4 +1,5 @@
 @using System.Text.Json
+@using Umbraco.Commerce.Checkout.Extensions
 @inherits UmbracoViewPage
 @{
     Layout = "UmbracoCommerceCheckoutLayout.cshtml";
@@ -6,6 +7,11 @@
     var store = Model.GetStore();
 
     var currentOrder = await UmbracoCommerceApi.Instance.GetCurrentOrderAsync(store.Id);
+    var orderPropertyConfig = await UmbracoCommerceApi.Instance.GetOrderPropertyConfigAsync(store.Alias);
+
+    var customer = currentOrder.GetCustomer(orderPropertyConfig);
+    var billingAddress = currentOrder.GetBillingAddress(orderPropertyConfig);
+    var shippingAddress = currentOrder.GetShippingAddress(orderPropertyConfig);
 
     var countries = await UmbracoCommerceApi.Instance.GetCountriesAsync(store.Id);
 
@@ -43,7 +49,7 @@
 
     <h3 class="text-xl font-medium mb-4">@Umbraco.GetDictionaryValueOrDefault("UmbracoCommerceCheckout.Information.ContactInformation", "Contact Information")</h3>
     <input name="email" type="email" placeholder="@Umbraco.GetDictionaryValueOrDefault("UmbracoCommerceCheckout.Information.Email", "Email")" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 w-full"
-           value="@(currentOrder.CustomerInfo.Email)" required />
+           value="@(customer.Email ?? currentOrder.CustomerInfo.Email)" required />
     <label class="flex items-center mb-2  cursor-pointer">
         <input name="marketingOptIn" type="checkbox" value="true" class="mr-2" @Html.Raw(currentOrder.Properties["marketingOptIn"] == "1" ? "checked=\"checked\"" : "") /> @Umbraco.GetDictionaryValueOrDefault("UmbracoCommerceCheckout.Information.MarketingOptIn", "Keep me up to date on news and exclusive offers")
     </label>
@@ -52,17 +58,17 @@
 
     <div class="flex -mx-1">
         <input name="billingAddress.Firstname" type="text" placeholder="@Umbraco.GetDictionaryValueOrDefault("UmbracoCommerceCheckout.Information.FirstName", "First Name")" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 mx-1 w-full"
-               value="@(currentOrder.CustomerInfo.FirstName)" required />
+               value="@(customer.FirstName ?? currentOrder.CustomerInfo.FirstName)" required />
         <input name="billingAddress.Lastname" type="text" placeholder="@Umbraco.GetDictionaryValueOrDefault("UmbracoCommerceCheckout.Information.LastName", "Last Name")" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 mx-1 w-full"
-               value="@(currentOrder.CustomerInfo.LastName)" required />
+               value="@(customer.LastName ??currentOrder.CustomerInfo.LastName)" required />
     </div>
 
     <input name="billingAddress.Line1" type="text" placeholder="@Umbraco.GetDictionaryValueOrDefault("UmbracoCommerceCheckout.Information.Address1", "Address (Line 1)")" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 w-full"
-           value="@(currentOrder.Properties["billingAddressLine1"])" required />
+           value="@(billingAddress.AddressLine1 ?? currentOrder.Properties["billingAddressLine1"])" required />
     <input name="billingAddress.Line2" type="text" placeholder="@Umbraco.GetDictionaryValueOrDefault("UmbracoCommerceCheckout.Information.Address2", "Address (Line 2)")" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 w-full"
-           value="@(currentOrder.Properties["billingAddressLine2"])" />
+           value="@(billingAddress.AddressLine2 ?? currentOrder.Properties["billingAddressLine2"])" />
     <input name="billingAddress.City" type="text" placeholder="@Umbraco.GetDictionaryValueOrDefault("UmbracoCommerceCheckout.Information.City", "City")" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 w-full"
-           value="@(currentOrder.Properties["billingCity"])" required />
+           value="@(billingAddress.City ?? currentOrder.Properties["billingCity"])" required />
 
     <div class="flex -mx-1">
         <select name="billingAddress.Country" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 mx-1 w-full" required>
@@ -82,10 +88,10 @@
         <select name="billingAddress.Region" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 mx-1 w-full disabled:hidden"
                 data-value="@currentOrder.PaymentInfo.RegionId" data-placeholder="@Umbraco.GetDictionaryValueOrDefault("UmbracoCommerceCheckout.Information.SelectRegion", "-- Select a Region --")" required disabled></select>
         <input name="billingAddress.ZipCode" type="text" placeholder="@Umbraco.GetDictionaryValueOrDefault("UmbracoCommerceCheckout.Information.ZipCode", "Postcode")" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 mx-1 w-full"
-               value="@(currentOrder.Properties["billingZipCode"])" required />
+               value="@(billingAddress.ZipCode ?? currentOrder.Properties["billingZipCode"])" required />
     </div>
     <input name="billingAddress.Telephone" type="text" placeholder="@Umbraco.GetDictionaryValueOrDefault("UmbracoCommerceCheckout.Information.Telephone", "Phone")" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 w-full"
-           value="@(currentOrder.Properties["billingTelephone"])" />
+           value="@(customer.Telephone ?? currentOrder.Properties["billingTelephone"])" />
 
     if (checkoutPage.Value<bool>("uccCollectShippingInfo"))
     {
@@ -99,17 +105,17 @@
 
             <div class="flex -mx-1">
                 <input name="shippingAddress.Firstname" type="text" placeholder="@Umbraco.GetDictionaryValueOrDefault("UmbracoCommerceCheckout.Information.FirstName", "First Name")" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 mx-1 w-full"
-                       value="@(currentOrder.Properties["shippingFirstName"])" required />
+                       value="@(customer.FirstName ?? currentOrder.Properties["shippingFirstName"])" required />
                 <input name="shippingAddress.Lastname" type="text" placeholder="@Umbraco.GetDictionaryValueOrDefault("UmbracoCommerceCheckout.Information.LastName", "Last Name")" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 mx-1 w-full"
-                       value="@(currentOrder.Properties["shippingLastName"])" required />
+                       value="@(customer.LastName ?? currentOrder.Properties["shippingLastName"])" required />
             </div>
 
             <input name="shippingAddress.Line1" type="text" placeholder="@Umbraco.GetDictionaryValueOrDefault("UmbracoCommerceCheckout.Information.Address1", "Address (Line 1)")" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 w-full"
-                   value="@(currentOrder.Properties["shippingAddressLine1"])" required />
+                   value="@(shippingAddress.AddressLine1 ?? currentOrder.Properties["shippingAddressLine1"])" required />
             <input name="shippingAddress.Line2" type="text" placeholder="@Umbraco.GetDictionaryValueOrDefault("UmbracoCommerceCheckout.Information.Address2", "Address (Line 2)")" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 w-full"
-                   value="@(currentOrder.Properties["shippingAddressLine2"])" />
+                   value="@(shippingAddress.AddressLine2 ?? currentOrder.Properties["shippingAddressLine2"])" />
             <input name="shippingAddress.City" type="text" placeholder="@Umbraco.GetDictionaryValueOrDefault("UmbracoCommerceCheckout.Information.City", "City")" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 w-full"
-                   value="@(currentOrder.Properties["shippingCity"])" required />
+                   value="@(shippingAddress.City ?? currentOrder.Properties["shippingCity"])" required />
 
             <div class="flex -mx-1">
                 <select name="shippingAddress.Country" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 mx-1 w-full" required>
@@ -129,10 +135,10 @@
                 <select name="shippingAddress.Region" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 mx-1 w-full disabled:hidden"
                         data-value="@currentOrder.ShippingInfo.RegionId" data-placeholder="@Umbraco.GetDictionaryValueOrDefault("UmbracoCommerceCheckout.Information.SelectRegion", "-- Select a Region --")" required disabled></select>
                 <input name="shippingAddress.ZipCode" type="text" placeholder="@Umbraco.GetDictionaryValueOrDefault("UmbracoCommerceCheckout.Information.ZipCode", "Postcode")" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 mx-1 w-full"
-                       value="@(currentOrder.Properties["shippingZipCode"])" required />
+                       value="@(shippingAddress.ZipCode ?? currentOrder.Properties["shippingZipCode"])" required />
             </div>
             <input name="shippingAddress.Telephone" type="text" placeholder="@Umbraco.GetDictionaryValueOrDefault("UmbracoCommerceCheckout.Information.Telephone", "Phone")" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 w-full"
-                   value="@(currentOrder.Properties["shippingTelephone"])" />
+                   value="@(customer.Telephone ?? currentOrder.Properties["shippingTelephone"])" />
 
         </div>
     }

--- a/src/Umbraco.Commerce.Checkout/Web/Controllers/UmbracoCommerceCheckoutBaseController.cs
+++ b/src/Umbraco.Commerce.Checkout/Web/Controllers/UmbracoCommerceCheckoutBaseController.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ViewEngines;
@@ -40,8 +41,6 @@ namespace Umbraco.Commerce.Checkout.Web.Controllers
 
         protected async Task<bool> IsValidCartAsync()
         {
-            ArgumentNullException.ThrowIfNull(CurrentPage);
-
             StoreReadOnly store = CurrentPage.GetStore();
             OrderReadOnly order = !IsConfirmationPageType(CurrentPage)
                 ? await UmbracoCommerceApi.Instance.GetCurrentOrderAsync(store.Id)
@@ -53,6 +52,14 @@ namespace Umbraco.Commerce.Checkout.Web.Controllers
             }
 
             return true;
+        }
+
+        protected bool IsLoginRequired(out string loginPageUrl)
+        {
+            IPublishedContent checkoutPage = CurrentPage.GetCheckoutPage();
+            IPublishedContent loginPage = CurrentPage.GetLoginPage();
+            loginPageUrl = loginPage?.Url(Thread.CurrentThread.CurrentCulture.Name) ?? string.Empty;
+            return checkoutPage?.Value<bool>("uccRequireLogin") ?? false;
         }
 
         private static bool IsConfirmationPageType(IPublishedContent node)

--- a/src/Umbraco.Commerce.Checkout/Web/Controllers/UmbracoCommerceCheckoutCheckoutPageController.cs
+++ b/src/Umbraco.Commerce.Checkout/Web/Controllers/UmbracoCommerceCheckoutCheckoutPageController.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ViewEngines;
 using Microsoft.Extensions.Logging;
+using Umbraco.Cms.Web.Common.Filters;
 using Umbraco.Extensions;
 
 namespace Umbraco.Commerce.Checkout.Web.Controllers
@@ -23,13 +25,22 @@ namespace Umbraco.Commerce.Checkout.Web.Controllers
 
         public override async Task<IActionResult> Index()
         {
+            ArgumentNullException.ThrowIfNull(CurrentPage);
+
+            // Check if login is required
+            if (IsLoginRequired(out string loginPageUrl) && (!User.Identity?.IsAuthenticated ?? false))
+            {
+                return string.IsNullOrEmpty(loginPageUrl)
+                    ? Unauthorized()
+                    : Redirect(loginPageUrl);
+            }
+
             // Check the cart is valid before continuing
             if (!await IsValidCartAsync())
             {
                 return Redirect(InvalidCartRedirectUrl);
             }
 
-            ArgumentNullException.ThrowIfNull(CurrentPage);
             // If the page has a template, use it
             if (CurrentPage.TemplateId.HasValue && CurrentPage.TemplateId.Value > 0)
             {

--- a/src/Umbraco.Commerce.Checkout/Web/Controllers/UmbracoCommerceCheckoutCheckoutStepPageController.cs
+++ b/src/Umbraco.Commerce.Checkout/Web/Controllers/UmbracoCommerceCheckoutCheckoutStepPageController.cs
@@ -2,6 +2,9 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ViewEngines;
 using Microsoft.Extensions.Logging;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Commerce.Core.Api;
+using Umbraco.Commerce.Extensions;
 using Umbraco.Extensions;
 
 namespace Umbraco.Commerce.Checkout.Web.Controllers
@@ -21,6 +24,14 @@ namespace Umbraco.Commerce.Checkout.Web.Controllers
 
         public override async Task<IActionResult> Index()
         {
+            // Check if login is required
+            if (IsLoginRequired(out string loginPageUrl) && (!User.Identity?.IsAuthenticated ?? false))
+            {
+                return string.IsNullOrEmpty(loginPageUrl)
+                    ? Unauthorized()
+                    : Redirect(loginPageUrl);
+            }
+
             // Check the cart is valid before continuing
             if (!await IsValidCartAsync())
             {

--- a/src/Umbraco.Commerce.Checkout/Web/PublishedContentExtensions.cs
+++ b/src/Umbraco.Commerce.Checkout/Web/PublishedContentExtensions.cs
@@ -30,6 +30,11 @@ namespace Umbraco.Commerce.Checkout.Web
             return GetCheckoutPage(content).Value<IPublishedContent>("uccBackPage")!;
         }
 
+        public static IPublishedContent GetLoginPage(this IPublishedContent content)
+        {
+            return GetCheckoutPage(content).Value<IPublishedContent>("uccLoginPage")!;
+        }
+
         public static string GetThemeColor(this IPublishedContent content)
         {
             // Check if the checkout page has a custom theme color set


### PR DESCRIPTION
Current PR adds support for an authorized checkout flow with the following additional features implemented:
* Add settings to the `Checkout` page to specify whether login is required, and specified the login content node. If login is required but no login page has been specified, the action result will be `Unauthorized`.
* Upon checkout, the customer information will be retrieved from the details of the logged in user using the implemented extension methods.

Using the `Checkout` add-on in parallel with the `Portal` one, upon login the customer will be automatically assigned to the current order.

FYI @umbracotrd 