### PR TITLE
#814: Fallback to zero value payment method by provider alias

### DIFF
--- a/src/Umbraco.Commerce.Checkout/Views/UmbracoCommerceCheckout/Templates/Email/UmbracoCommerceCheckoutOrderConfirmationEmail.cshtml
+++ b/src/Umbraco.Commerce.Checkout/Views/UmbracoCommerceCheckout/Templates/Email/UmbracoCommerceCheckoutOrderConfirmationEmail.cshtml
@@ -267,7 +267,7 @@
                                     </tr>
                                 }
 
-                                @if (paymentMethod != null && paymentMethod.Alias != UmbracoCommerceCheckoutConstants.PaymentMethods.Aliases.ZeroValue)
+                                @if (paymentMethod != null && paymentMethod.PaymentProviderAlias != "zeroValue")
                                 {
                                     <tr>
                                         <td style="vertical-align: top;">

--- a/src/Umbraco.Commerce.Checkout/Views/UmbracoCommerceCheckout/UmbracoCommerceCheckoutPaymentMethodPage.cshtml
+++ b/src/Umbraco.Commerce.Checkout/Views/UmbracoCommerceCheckout/UmbracoCommerceCheckoutPaymentMethodPage.cshtml
@@ -9,12 +9,12 @@
     var paymentCountry = currentOrder.PaymentInfo.CountryId.HasValue
         ? await UmbracoCommerceApi.Instance.GetCountryAsync(currentOrder.PaymentInfo.CountryId.Value)
         : null;
+
     var paymentRegion = currentOrder.PaymentInfo.RegionId.HasValue
         ? await UmbracoCommerceApi.Instance.GetCountryAsync(currentOrder.PaymentInfo.RegionId.Value)
         : null;
 
-    var paymentMethods = await UmbracoCommerceApi.Instance.GetPaymentMethodsAllowedInAsync(currentOrder.PaymentInfo.CountryId.Value,
-        currentOrder.PaymentInfo.RegionId);
+    var paymentMethods = await UmbracoCommerceApi.Instance.GetPaymentMethodsAllowedInAsync(currentOrder.PaymentInfo.CountryId.Value, currentOrder.PaymentInfo.RegionId);
 
     var currentPaymentMethodId = currentOrder.PaymentInfo.PaymentMethodId.HasValue
         ? currentOrder.PaymentInfo.PaymentMethodId.Value
@@ -24,9 +24,11 @@
                 ? paymentCountry.DefaultPaymentMethodId.Value
                 : paymentMethods.FirstOrDefault()?.Id;
 
-    var zeroValuePaymentMethod = paymentMethods.FirstOrDefault(x => x.Alias == UmbracoCommerceCheckoutConstants.PaymentMethods.Aliases.ZeroValue);
+    var zeroValuePaymentMethod = paymentMethods.FirstOrDefault(x => x.Alias == UmbracoCommerceCheckoutConstants.PaymentMethods.Aliases.ZeroValue)
+        ?? paymentMethods.FirstOrDefault(x => x.PaymentProviderAlias != "zeroValue");
 
     var checkoutPage = Model.GetCheckoutPage();
+
     var nextStepPage = Model.GetNextStepPage();
 }
 
@@ -39,10 +41,10 @@
     if (currentOrder.TransactionAmount.Value > 0 || zeroValuePaymentMethod == null)
     {
         <ul class="border border-gray-300 rounded">
-            @foreach (var item in paymentMethods.Where(x => zeroValuePaymentMethod == null || x.Alias != zeroValuePaymentMethod.Alias)
-           .Select((pm, i) => new { PaymentMethod = pm, Index = i }))
+            @foreach (var item in paymentMethods.Where(x => zeroValuePaymentMethod == null || x.Alias != zeroValuePaymentMethod.Alias).Select((pm, i) => new { PaymentMethod = pm, Index = i }))
             {
                 var fee = await item.PaymentMethod.TryCalculateFeeAsync(currentOrder);
+
                 if (fee.Success)
                 {
                     <li class="border-gray-300 @(item.Index > 0 ? "border-t " : "")">


### PR DESCRIPTION
Fixes [#814](https://github.com/umbraco/Umbraco.Commerce.Issues/issues/814)

Umbraco Commerce Checkout requires that you have a payment provider with the alias `uccZeroValue` in order to process orders that do not require payment.

If a provider with this alias does not exist all other providers will fail / error. If you create a zero value provider with a different alias then the user is always shown all configured options.

This PR:

- Falls back to using the first payment provider with provider alias of `zeroValue` when the order value is zero – this keep backwards compatibility with the existing behaviour if a `uccZeroValue` provider does exist

- Shows payment amount / via in the confirmation email except when *any* `zeroValue` payment method is used, not just `uccZeroValue`

_Note: there is some logic that keeps the uccZeroValue confirm URL in sync, which will continue to work. I don't know the history of that, feels a bit weird, so have left it alone._

It would be really awesome if this could be backported to v13 also! Let me know if you need another PR for that...